### PR TITLE
Fix mix deps import

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule SpandexDatadog.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:spandex, ">= 2.0"},
+      {:spandex, "~> 2.0"},
       {:httpoison, "~> 0.13", only: :test},
       {:msgpax, "~> 1.1"}
     ]


### PR DESCRIPTION
When trying to import spandex_datadog using 
```
{:spandex_datadog,
       git: "https://github.com/zachdaniel/spandex_datadog",
       ref: "99c4cfee1d28732cb8aad1afee383de3969b2160"}
```
I was having this issue. (Elixir 1.6.2)
```
** (Mix) Required version ">= 2.0" for package spandex is incorrectly specified (from: deps/spandex_datadog/mix.exs)
```
I had to change the version format to have it working.