### PR TITLE
Read sampling priority from request headers

### DIFF
--- a/lib/spandex_datadog/adapter.ex
+++ b/lib/spandex_datadog/adapter.ex
@@ -30,19 +30,21 @@ defmodule SpandexDatadog.Adapter do
   """
   @impl Spandex.Adapter
   @spec distributed_context(conn :: Plug.Conn.t(), Keyword.t()) ::
-          {:ok, %{trace_id: binary, parent_id: binary}} | {:error, :no_trace_context}
+          {:ok, %{trace_id: Spandex.id(), parent_id: Spandex.id(), priority: integer()}}
+          | {:error, :no_trace_context}
   def distributed_context(%Plug.Conn{} = conn, _opts) do
     trace_id = get_first_header(conn, "x-datadog-trace-id")
     parent_id = get_first_header(conn, "x-datadog-parent-id")
+    priority = get_first_header(conn, "x-datadog-sampling-priority") || 1
 
     if is_nil(trace_id) || is_nil(parent_id) do
       {:error, :no_distributed_trace}
     else
-      {:ok, %{trace_id: trace_id, parent_id: parent_id}}
+      {:ok, %{trace_id: trace_id, parent_id: parent_id, priority: priority}}
     end
   end
 
-  @spec get_first_header(conn :: Plug.Conn.t(), header_name :: binary) :: binary | nil
+  @spec get_first_header(Plug.Conn.t(), String.t()) :: String.t() | nil
   defp get_first_header(conn, header_name) do
     conn
     |> Plug.Conn.get_req_header(header_name)


### PR DESCRIPTION
This is still WIP, but I wanted to mention that I'm starting to work on it so we can figure out which parts should be extensions to the core `Spandex` library and which parts belong here.

My initial impression is that we should change the API on the `Spandex` side so that the `distributed_context` callback returns a `TraceContext` struct with `trace_id`, `span_id`, `priority`, and `baggage` (keyword list of additional data).

[OpenTracing docs about storing sampling priority in a SpanContext structure, along with trace_id and span_id](https://github.com/opentracing/specification/blob/master/specification.md#the-opentracing-data-model)
[Datadog docs about how priority sampling works](https://docs.datadoghq.com/tracing/getting_further/trace_sampling_and_storage/#priority-sampling-for-distributed-tracing)
[Datadog docs about how their trace agent handles priority sampling](https://github.com/DataDog/datadog-trace-agent/wiki/Distributed-Priority-Sampling)
[Docs for configuring the official ddtrace Ruby gem for priority sampling](https://www.rubydoc.info/gems/ddtrace/#Priority_sampling_)
