### PR TITLE
Default span resource to span name if not set

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -219,7 +219,7 @@ defmodule SpandexDatadog.ApiServer do
       duration: (span.completion_time || SpandexDatadog.Adapter.now()) - span.start,
       parent_id: span.parent_id,
       error: error(span.error),
-      resource: span.resource,
+      resource: span.resource || span.name,
       service: span.service,
       type: span.type,
       meta: meta(span),


### PR DESCRIPTION
The Datadog trace collector drops any traces that have spans in them that don't have a `resource` set. Spandex itself doesn't require this field to be set, so I'm proposing that we default it at the last minute before sending the trace to Datadog.