### PR TITLE
Clarify the concurrency backpressure features of sync_threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ backpressure.
 
 A simple way to think about it is that if you are seeing 1000
 request per second and `batch_size` is 10, then you'll be making 100
-requests per second to Datadog (probably a bad config). With
-`sync_threshold` set to 10, only 10 of those requests can be processed concurrently before the work is done synchronously 
-(not waiting for the asynchronous ones to complete even). 
+requests per second to Datadog (probably a bad config). 
+With `sync_threshold` set to 10, only 10 of those requests can be 
+processed concurrently before trace calls become synchronous. 
+
 This concept of backpressure is very important, and strategies
 for switching to synchronous operation are often surprisingly far more
 performant than purely asynchronous strategies (and much more predictable).

--- a/README.md
+++ b/README.md
@@ -62,19 +62,18 @@ Batch size refers to *traces*, not spans, so if you send a large amount of spans
 per trace, then you probably want to keep that number low. If you send only a
 few spans, then you could set it significantly higher.
 
-Sync threshold refers to the *number of processes concurrently sending spans*,
-*NOT* the number of traces queued up waiting to be sent. It is used to apply
-backpressure while still taking advantage of parallelism. Ideally, the sync
-threshold would be set to a point that you wouldn't reasonably reach often, but
+Sync threshold is how many _simultaneous_ HTTP pushes will be going to Datadog 
+before it blocks/throttles your application by making the tracing call synchronous instead of async.
+
+Ideally, the sync threshold would be set to a point that you wouldn't reasonably reach often, but
 that is low enough to not cause systemic performance issues if you don't apply
 backpressure.
 
 A simple way to think about it is that if you are seeing 1000
-request per second and your batch size is 10, then you'll be making 100
-requests per second to Datadog (probably a bad config). If your
-`sync_threshold` is set to 10, you'll almost certainly exceed that because 100
-requests in 1 second will likely overlap in that way. So when that is exceeded,
-the work is done synchronously, (not waiting for the asynchronous ones to
-complete even). This concept of backpressure is very important, and strategies
+request per second and `batch_size` is 10, then you'll be making 100
+requests per second to Datadog (probably a bad config). With
+`sync_threshold` set to 10, only 10 of those requests can be processed concurrently before the work is done synchronously 
+(not waiting for the asynchronous ones to complete even). 
+This concept of backpressure is very important, and strategies
 for switching to synchronous operation are often surprisingly far more
 performant than purely asynchronous strategies (and much more predictable).


### PR DESCRIPTION
I had some trouble parsing exactly what sync_threshold was and how I should configure it for production. A conversation w/ @GregMefford helped clarify things for me, and so I've done my best to embed that information in the readme. 
Not sure if this is an improvement for everyone or just for me with my newfound understanding, so please suggest any additional changes, or dismiss the PR with no guilt =)