### PR TITLE
Ensure tags are converted to strings

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -305,7 +305,12 @@ defmodule SpandexDatadog.ApiServer do
   defp add_tags(meta, %{tags: nil}), do: meta
 
   defp add_tags(meta, %{tags: tags}) do
-    Map.merge(meta, Enum.into(tags, %{}))
+    Map.merge(
+      meta,
+      tags
+      |> Enum.map(fn {k, v} -> {k, term_to_string(v)} end)
+      |> Enum.into(%{})
+    )
   end
 
   @spec error(nil | Keyword.t()) :: integer
@@ -346,4 +351,14 @@ defmodule SpandexDatadog.ApiServer do
   end
 
   defp deep_remove_nils(term), do: term
+
+  defp term_to_string(term) do
+    case String.Chars.impl_for(term) do
+      nil ->
+        inspect(term)
+
+      _to_string_implementation ->
+        to_string(term)
+    end
+  end
 end

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -352,13 +352,7 @@ defmodule SpandexDatadog.ApiServer do
 
   defp deep_remove_nils(term), do: term
 
-  defp term_to_string(term) do
-    case String.Chars.impl_for(term) do
-      nil ->
-        inspect(term)
-
-      _to_string_implementation ->
-        to_string(term)
-    end
-  end
+  defp term_to_string(term) when is_binary(term), do: term
+  defp term_to_string(term) when is_atom(term), do: term
+  defp term_to_string(term), do: inspect(term)
 end

--- a/test/support/api_server_test.exs
+++ b/test/support/api_server_test.exs
@@ -36,7 +36,8 @@ defmodule SpandexDatadog.ApiServerTest do
         env: "local",
         name: "foo",
         trace_id: trace_id,
-        completion_time: 1_527_752_052_216_578_000
+        completion_time: 1_527_752_052_216_578_000,
+        tags: [foo: "123", bar: 321, baz: {1, 2}]
       )
 
     {:ok, span_2} =
@@ -84,7 +85,7 @@ defmodule SpandexDatadog.ApiServerTest do
         %{
           "duration" => 100_000,
           "error" => 0,
-          "meta" => %{"env" => "local"},
+          "meta" => %{"env" => "local", "foo" => "123", "bar" => "321", "baz" => "{1, 2}"},
           "name" => "foo",
           "service" => "foo",
           "resource" => "foo",
@@ -135,7 +136,7 @@ defmodule SpandexDatadog.ApiServerTest do
         %{
           "duration" => 100_000,
           "error" => 0,
-          "meta" => %{"env" => "local"},
+          "meta" => %{"env" => "local", "foo" => "123", "bar" => "321", "baz" => "{1, 2}"},
           "name" => "foo",
           "service" => "foo",
           "resource" => "foo",

--- a/test/support/api_server_test.exs
+++ b/test/support/api_server_test.exs
@@ -37,7 +37,7 @@ defmodule SpandexDatadog.ApiServerTest do
         name: "foo",
         trace_id: trace_id,
         completion_time: 1_527_752_052_216_578_000,
-        tags: [foo: "123", bar: 321, baz: {1, 2}]
+        tags: [foo: "123", bar: 321, baz: {1, 2}, zyx: [xyz: {1, 2}]]
       )
 
     {:ok, span_2} =
@@ -85,7 +85,13 @@ defmodule SpandexDatadog.ApiServerTest do
         %{
           "duration" => 100_000,
           "error" => 0,
-          "meta" => %{"env" => "local", "foo" => "123", "bar" => "321", "baz" => "{1, 2}"},
+          "meta" => %{
+            "env" => "local",
+            "foo" => "123",
+            "bar" => "321",
+            "baz" => "{1, 2}",
+            "zyx" => "[xyz: {1, 2}]"
+          },
           "name" => "foo",
           "service" => "foo",
           "resource" => "foo",
@@ -136,7 +142,13 @@ defmodule SpandexDatadog.ApiServerTest do
         %{
           "duration" => 100_000,
           "error" => 0,
-          "meta" => %{"env" => "local", "foo" => "123", "bar" => "321", "baz" => "{1, 2}"},
+          "meta" => %{
+            "env" => "local",
+            "foo" => "123",
+            "bar" => "321",
+            "baz" => "{1, 2}",
+            "zyx" => "[xyz: {1, 2}]"
+          },
           "name" => "foo",
           "service" => "foo",
           "resource" => "foo",


### PR DESCRIPTION
Spandex allows arbitrary types for tag values, but Datadog only accepts strings. This change makes sure that any term can be submitted as tag value. If `String.Chars` is implemented for its type, the adapter will use `to_string`, and fallback to `inspect` otherwise.