### PR TITLE
Optimize api server collection

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -2,38 +2,18 @@ defmodule SpandexDatadog.ApiServer do
   @moduledoc """
   Implements worker for sending spans to datadog as GenServer in order to send traces async.
   """
+  use Supervisor
 
-  use GenServer
-  require Logger
+  alias __MODULE__.Buffer
+  alias __MODULE__.Client
+  alias __MODULE__.Reporter
 
   alias Spandex.{
     Span,
     Trace
   }
 
-  defmodule State do
-    @moduledoc false
-
-    @type t :: %State{}
-
-    defstruct [
-      :asynchronous_send?,
-      :http,
-      :url,
-      :host,
-      :port,
-      :verbose?,
-      :waiting_traces,
-      :batch_size,
-      :sync_threshold,
-      :agent_pid
-    ]
-  end
-
-  # Same as HTTPoison.headers
-  @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary} | any
-
-  @headers [{"Content-Type", "application/msgpack"}]
+  require Logger
 
   @start_link_opts Optimal.schema(
                      opts: [
@@ -76,39 +56,31 @@ defmodule SpandexDatadog.ApiServer do
   def start_link(opts) do
     opts = Optimal.validate!(opts, @start_link_opts)
 
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @doc """
-  Builds server state.
-  """
-  @spec init(opts :: Keyword.t()) :: {:ok, State.t()}
   def init(opts) do
-    {:ok, agent_pid} = Agent.start_link(fn -> 0 end)
+    buffer = Buffer.new()
+    reporter_opts =
+      opts
+      |> Map.new()
+      |> Map.take([:http, :verbose?, :host, :port])
+      |> Map.put(:buffer, buffer)
 
-    state = %State{
-      asynchronous_send?: true,
-      host: opts[:host],
-      port: opts[:port],
-      verbose?: opts[:verbose?],
-      http: opts[:http],
-      waiting_traces: [],
-      batch_size: opts[:batch_size],
-      sync_threshold: opts[:sync_threshold],
-      agent_pid: agent_pid
-    }
+    children = [
+      {Reporter, reporter_opts},
+    ]
 
-    {:ok, state}
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
   @doc """
   Send spans asynchronously to DataDog.
   """
   @spec send_trace(Trace.t(), Keyword.t()) :: :ok
-  def send_trace(%Trace{} = trace, opts \\ []) do
+  def send_trace(%Trace{} = trace, _opts \\ []) do
     :telemetry.span([:spandex_datadog, :send_trace], %{trace: trace}, fn ->
-      timeout = Keyword.get(opts, :timeout, 30_000)
-      result = GenServer.call(__MODULE__, {:send_trace, trace}, timeout)
+      result = Buffer.add_trace(trace)
       {result, %{trace: trace}}
     end)
   end
@@ -117,276 +89,15 @@ defmodule SpandexDatadog.ApiServer do
   @doc false
   @spec send_spans([Span.t()], Keyword.t()) :: :ok
   def send_spans(spans, opts \\ []) when is_list(spans) do
-    timeout = Keyword.get(opts, :timeout, 30_000)
     trace = %Trace{spans: spans}
-    GenServer.call(__MODULE__, {:send_trace, trace}, timeout)
+    send_trace(trace, opts)
   end
+
+  # Leaving these here for api versioning purposes. But this logic has
+  # been moved to the client module.
+  @doc false
+  def format(trace), do: Client.format(trace)
 
   @doc false
-  def handle_call({:send_trace, trace}, _from, state) do
-    state =
-      state
-      |> enqueue_trace(trace)
-      |> maybe_flush_traces()
-
-    {:reply, :ok, state}
-  end
-
-  @spec send_and_log([Trace.t()], State.t()) :: :ok
-  def send_and_log(traces, %{verbose?: verbose?} = state) do
-    headers = @headers ++ [{"X-Datadog-Trace-Count", length(traces)}]
-
-    response =
-      traces
-      |> Enum.map(&format/1)
-      |> encode()
-      |> push(headers, state)
-
-    if verbose? do
-      Logger.debug(fn -> "Trace response: #{inspect(response)}" end)
-    end
-
-    :ok
-  end
-
-  @deprecated "Please use format/3 instead"
-  @spec format(Trace.t()) :: map()
-  def format(%Trace{spans: spans, priority: priority, baggage: baggage}) do
-    Enum.map(spans, fn span -> format(span, priority, baggage) end)
-  end
-
-  @deprecated "Please use format/3 instead"
-  @spec format(Span.t()) :: map()
-  def format(%Span{} = span), do: format(span, 1, [])
-
-  @spec format(Span.t(), integer(), Keyword.t()) :: map()
-  def format(%Span{} = span, priority, _baggage) do
-    %{
-      trace_id: span.trace_id,
-      span_id: span.id,
-      name: span.name,
-      start: span.start,
-      duration: (span.completion_time || SpandexDatadog.Adapter.now()) - span.start,
-      parent_id: span.parent_id,
-      error: error(span.error),
-      resource: span.resource || span.name,
-      service: span.service,
-      type: span.type,
-      meta: meta(span),
-      metrics:
-        metrics(span, %{
-          _sampling_priority_v1: priority
-        })
-    }
-  end
-
-  # Private Helpers
-
-  defp enqueue_trace(state, trace) do
-    if state.verbose? do
-      Logger.info(fn -> "Adding trace to stack with #{Enum.count(trace.spans)} spans" end)
-    end
-
-    %State{state | waiting_traces: [trace | state.waiting_traces]}
-  end
-
-  defp maybe_flush_traces(%{waiting_traces: traces, batch_size: size} = state) when length(traces) < size do
-    state
-  end
-
-  defp maybe_flush_traces(state) do
-    %{
-      asynchronous_send?: async?,
-      verbose?: verbose?,
-      waiting_traces: traces
-    } = state
-
-    if verbose? do
-      span_count = Enum.reduce(traces, 0, fn trace, acc -> acc + length(trace.spans) end)
-      Logger.info(fn -> "Sending #{length(traces)} traces, #{span_count} spans." end)
-      Logger.debug(fn -> "Trace: #{inspect(traces)}" end)
-    end
-
-    if async? do
-      if below_sync_threshold?(state) do
-        Task.start(fn ->
-          try do
-            send_and_log(traces, state)
-          after
-            Agent.update(state.agent_pid, fn count -> count - 1 end)
-          end
-        end)
-      else
-        # We get benefits from running in a separate process (like better GC)
-        # So we async/await here to mimic the behavour above but still apply backpressure
-        task = Task.async(fn -> send_and_log(traces, state) end)
-        Task.await(task)
-      end
-    else
-      send_and_log(traces, state)
-    end
-
-    %State{state | waiting_traces: []}
-  end
-
-  defp below_sync_threshold?(state) do
-    Agent.get_and_update(state.agent_pid, fn count ->
-      if count < state.sync_threshold do
-        {true, count + 1}
-      else
-        {false, count}
-      end
-    end)
-  end
-
-  @spec meta(Span.t()) :: map
-  defp meta(span) do
-    %{}
-    |> add_datadog_meta(span)
-    |> add_error_data(span)
-    |> add_http_data(span)
-    |> add_sql_data(span)
-    |> add_tags(span)
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.into(%{})
-  end
-
-  @spec add_datadog_meta(map, Span.t()) :: map
-  defp add_datadog_meta(meta, %Span{env: nil}), do: meta
-
-  defp add_datadog_meta(meta, %Span{env: env}) do
-    Map.put(meta, :env, env)
-  end
-
-  @spec add_error_data(map, Span.t()) :: map
-  defp add_error_data(meta, %{error: nil}), do: meta
-
-  defp add_error_data(meta, %{error: error}) do
-    meta
-    |> add_error_type(error[:exception])
-    |> add_error_message(error[:exception])
-    |> add_error_stacktrace(error[:stacktrace])
-  end
-
-  @spec add_error_type(map, Exception.t() | nil) :: map
-  defp add_error_type(meta, nil), do: meta
-  defp add_error_type(meta, exception), do: Map.put(meta, "error.type", exception.__struct__)
-
-  @spec add_error_message(map, Exception.t() | nil) :: map
-  defp add_error_message(meta, nil), do: meta
-
-  defp add_error_message(meta, exception),
-    do: Map.put(meta, "error.msg", Exception.message(exception))
-
-  @spec add_error_stacktrace(map, list | nil) :: map
-  defp add_error_stacktrace(meta, nil), do: meta
-
-  defp add_error_stacktrace(meta, stacktrace),
-    do: Map.put(meta, "error.stack", Exception.format_stacktrace(stacktrace))
-
-  @spec add_http_data(map, Span.t()) :: map
-  defp add_http_data(meta, %{http: nil}), do: meta
-
-  defp add_http_data(meta, %{http: http}) do
-    status_code =
-      if http[:status_code] do
-        to_string(http[:status_code])
-      end
-
-    meta
-    |> Map.put("http.url", http[:url])
-    |> Map.put("http.status_code", status_code)
-    |> Map.put("http.method", http[:method])
-  end
-
-  @spec add_sql_data(map, Span.t()) :: map
-  defp add_sql_data(meta, %{sql_query: nil}), do: meta
-
-  defp add_sql_data(meta, %{sql_query: sql}) do
-    meta
-    |> Map.put("sql.query", sql[:query])
-    |> Map.put("sql.rows", sql[:rows])
-    |> Map.put("sql.db", sql[:db])
-  end
-
-  @spec add_tags(map, Span.t()) :: map
-  defp add_tags(meta, %{tags: nil}), do: meta
-
-  defp add_tags(meta, %{tags: tags}) do
-    tags = tags |> Keyword.delete(:analytics_event)
-
-    Map.merge(
-      meta,
-      tags
-      |> Enum.map(fn {k, v} -> {k, term_to_string(v)} end)
-      |> Enum.into(%{})
-    )
-  end
-
-  @spec metrics(Span.t(), map) :: map
-  defp metrics(span, initial_value = %{}) do
-    initial_value
-    |> add_metrics(span)
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.into(%{})
-  end
-
-  @spec add_metrics(map, Span.t()) :: map
-  defp add_metrics(metrics, %{tags: nil}), do: metrics
-
-  defp add_metrics(metrics, %{tags: tags}) do
-    with analytics_event <- tags |> Keyword.get(:analytics_event),
-         true <- analytics_event != nil do
-      Map.merge(
-        metrics,
-        %{"_dd1.sr.eausr" => 1}
-      )
-    else
-      _ ->
-        metrics
-    end
-  end
-
-  @spec error(nil | Keyword.t()) :: integer
-  defp error(nil), do: 0
-
-  defp error(keyword) do
-    if Enum.any?(keyword, fn {_, v} -> not is_nil(v) end) do
-      1
-    else
-      0
-    end
-  end
-
-  @spec encode(data :: term) :: iodata | no_return
-  defp encode(data),
-    do: data |> deep_remove_nils() |> Msgpax.pack!(data)
-
-  @spec push(body :: iodata(), headers, State.t()) :: any()
-  defp push(body, headers, %State{http: http, host: host, port: port}),
-    do: http.put("#{host}:#{port}/v0.3/traces", body, headers)
-
-  @spec deep_remove_nils(term) :: term
-  defp deep_remove_nils(term) when is_map(term) do
-    term
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.map(fn {k, v} -> {k, deep_remove_nils(v)} end)
-    |> Enum.into(%{})
-  end
-
-  defp deep_remove_nils(term) when is_list(term) do
-    if Keyword.keyword?(term) do
-      term
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-      |> Enum.map(fn {k, v} -> {k, deep_remove_nils(v)} end)
-    else
-      Enum.map(term, &deep_remove_nils/1)
-    end
-  end
-
-  defp deep_remove_nils(term), do: term
-
-  defp term_to_string(term) when is_binary(term), do: term
-  defp term_to_string(term) when is_atom(term), do: term
-  defp term_to_string(term), do: inspect(term)
+  def format(span, priority, baggage), do: Client.format(span, priority, baggage)
 end

--- a/lib/spandex_datadog/api_server/buffer.ex
+++ b/lib/spandex_datadog/api_server/buffer.ex
@@ -1,0 +1,56 @@
+defmodule SpandexDatadog.ApiServer.Buffer do
+  @moduledoc false
+  # The buffer is designed to efficiently gather traces and spans without blocking
+  # the calling process.
+  # It stores each "trace" in an ets table using the processes currect scheduler
+  # id. This helps reduce contention on each ets table since, in theory, only one process should be writing to a table at a time.
+  # We periodically flush all spans to datadog in the background.
+
+  defstruct tabs: []
+
+  # Builds a bunch of ets tables, 1 per scheduler and returns them in a struct
+  def new() do
+    # 1 index erlang ftw
+    tabs = for s <- 1..System.schedulers() do
+      :ets.new(:"#{__MODULE__}-#{s}", [:named_table, :set, :public, {:write_concurrency, true}])
+    end
+
+    %__MODULE__{tabs: tabs}
+  end
+
+  def add_trace(trace) do
+    buffer = :"#{__MODULE__}-#{:erlang.system_info(:scheduler_id)}"
+    index = :ets.update_counter(buffer, :index, 1, {:index, 0})
+    :ets.insert(buffer, {index, trace})
+  end
+
+  # Returns the latest messages and then deletes them from the buffer
+  def flush_latest(buffer, f) do
+    Enum.flat_map(buffer.tabs, fn tab ->
+      case :ets.lookup(tab, :index) do
+        [{:index, index}] ->
+          records = :ets.select(tab, select_spec(index))
+          f.(records)
+          :ets.select_delete(tab, delete_spec(index))
+          records
+
+        [] ->
+          []
+      end
+    end)
+  end
+
+  defp delete_spec(index) do
+    match_spec(index, true)
+  end
+
+  def select_spec(index) do
+    # If we're selecting stuff we need to get the second element
+    match_spec(index, :"$2")
+  end
+
+  defp match_spec(index, item) do
+    # Get integers less than the current index
+    [{{:"$1", :"$2"}, [{:andalso, {:is_integer, :"$1"}, {:"=<", :"$1", index}}], [item]}]
+  end
+end

--- a/lib/spandex_datadog/api_server/client.ex
+++ b/lib/spandex_datadog/api_server/client.ex
@@ -1,0 +1,211 @@
+defmodule SpandexDatadog.ApiServer.Client do
+  @moduledoc false
+  # This client module is used to interact with datadog.
+
+  # Same as HTTPoison.headers
+  @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary} | any
+
+  @headers [{"Content-Type", "application/msgpack"}]
+
+  alias Spandex.Span
+  alias Spandex.Trace
+
+  require Logger
+
+  # Accepts the client configuration and a list of traces.
+  @spec send(client :: module(), collector_url :: String.t(), [Trace.t()], Keyword.t()) :: :ok
+  def send(client, collector_url, traces, opts) do
+    headers = @headers ++ [{"X-Datadog-Trace-Count", length(traces)}]
+
+    body =
+      traces
+      |> Enum.map(&format/1)
+      |> encode()
+
+    response = client.put(collector_url, body, headers)
+
+    if opts[:verbose?] do
+      Logger.debug(fn -> "Trace response: #{inspect(response)}" end)
+    end
+
+    :ok
+  end
+
+  @deprecated "Please use format/3 instead"
+  @spec format(Trace.t()) :: map()
+  def format(%Trace{spans: spans, priority: priority, baggage: baggage}) do
+    Enum.map(spans, fn span -> format(span, priority, baggage) end)
+  end
+
+  @deprecated "Please use format/3 instead"
+  @spec format(Span.t()) :: map()
+  def format(%Span{} = span), do: format(span, 1, [])
+
+  @spec format(Span.t(), integer(), Keyword.t()) :: map()
+  def format(%Span{} = span, priority, _baggage) do
+    %{
+      trace_id: span.trace_id,
+      span_id: span.id,
+      name: span.name,
+      start: span.start,
+      duration: (span.completion_time || SpandexDatadog.Adapter.now()) - span.start,
+      parent_id: span.parent_id,
+      error: error(span.error),
+      resource: span.resource || span.name,
+      service: span.service,
+      type: span.type,
+      meta: meta(span),
+      metrics:
+        metrics(span, %{
+          _sampling_priority_v1: priority
+        })
+    }
+  end
+
+  @spec meta(Span.t()) :: map
+  defp meta(span) do
+    %{}
+    |> add_datadog_meta(span)
+    |> add_error_data(span)
+    |> add_http_data(span)
+    |> add_sql_data(span)
+    |> add_tags(span)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.into(%{})
+  end
+
+  @spec add_datadog_meta(map, Span.t()) :: map
+  defp add_datadog_meta(meta, %Span{env: nil}), do: meta
+
+  defp add_datadog_meta(meta, %Span{env: env}) do
+    Map.put(meta, :env, env)
+  end
+
+  @spec add_error_data(map, Span.t()) :: map
+  defp add_error_data(meta, %{error: nil}), do: meta
+
+  defp add_error_data(meta, %{error: error}) do
+    meta
+    |> add_error_type(error[:exception])
+    |> add_error_message(error[:exception])
+    |> add_error_stacktrace(error[:stacktrace])
+  end
+
+  @spec add_error_type(map, Exception.t() | nil) :: map
+  defp add_error_type(meta, nil), do: meta
+  defp add_error_type(meta, exception), do: Map.put(meta, "error.type", exception.__struct__)
+
+  @spec add_error_message(map, Exception.t() | nil) :: map
+  defp add_error_message(meta, nil), do: meta
+
+  defp add_error_message(meta, exception),
+    do: Map.put(meta, "error.msg", Exception.message(exception))
+
+  @spec add_error_stacktrace(map, list | nil) :: map
+  defp add_error_stacktrace(meta, nil), do: meta
+
+  defp add_error_stacktrace(meta, stacktrace),
+    do: Map.put(meta, "error.stack", Exception.format_stacktrace(stacktrace))
+
+  @spec add_http_data(map, Span.t()) :: map
+  defp add_http_data(meta, %{http: nil}), do: meta
+
+  defp add_http_data(meta, %{http: http}) do
+    status_code =
+      if http[:status_code] do
+        to_string(http[:status_code])
+      end
+
+    meta
+    |> Map.put("http.url", http[:url])
+    |> Map.put("http.status_code", status_code)
+    |> Map.put("http.method", http[:method])
+  end
+
+  @spec add_sql_data(map, Span.t()) :: map
+  defp add_sql_data(meta, %{sql_query: nil}), do: meta
+
+  defp add_sql_data(meta, %{sql_query: sql}) do
+    meta
+    |> Map.put("sql.query", sql[:query])
+    |> Map.put("sql.rows", sql[:rows])
+    |> Map.put("sql.db", sql[:db])
+  end
+
+  @spec add_tags(map, Span.t()) :: map
+  defp add_tags(meta, %{tags: nil}), do: meta
+
+  defp add_tags(meta, %{tags: tags}) do
+    tags = tags |> Keyword.delete(:analytics_event)
+
+    Map.merge(
+      meta,
+      tags
+      |> Enum.map(fn {k, v} -> {k, term_to_string(v)} end)
+      |> Enum.into(%{})
+    )
+  end
+
+  @spec metrics(Span.t(), map) :: map
+  defp metrics(span, initial_value = %{}) do
+    initial_value
+    |> add_metrics(span)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.into(%{})
+  end
+
+  @spec add_metrics(map, Span.t()) :: map
+  defp add_metrics(metrics, %{tags: nil}), do: metrics
+
+  defp add_metrics(metrics, %{tags: tags}) do
+    with analytics_event <- tags |> Keyword.get(:analytics_event),
+         true <- analytics_event != nil do
+      Map.merge(
+        metrics,
+        %{"_dd1.sr.eausr" => 1}
+      )
+    else
+      _ ->
+        metrics
+    end
+  end
+
+  @spec error(nil | Keyword.t()) :: integer
+  defp error(nil), do: 0
+
+  defp error(keyword) do
+    if Enum.any?(keyword, fn {_, v} -> not is_nil(v) end) do
+      1
+    else
+      0
+    end
+  end
+
+  @spec encode(data :: term) :: iodata | no_return
+  defp encode(data),
+    do: data |> deep_remove_nils() |> Msgpax.pack!(data)
+
+  @spec deep_remove_nils(term) :: term
+  defp deep_remove_nils(term) when is_map(term) do
+    term
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.map(fn {k, v} -> {k, deep_remove_nils(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp deep_remove_nils(term) when is_list(term) do
+    if Keyword.keyword?(term) do
+      term
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Enum.map(fn {k, v} -> {k, deep_remove_nils(v)} end)
+    else
+      Enum.map(term, &deep_remove_nils/1)
+    end
+  end
+
+  defp deep_remove_nils(term), do: term
+
+  defp term_to_string(term) when is_binary(term), do: term
+  defp term_to_string(term) when is_atom(term), do: term
+  defp term_to_string(term), do: inspect(term)
+end

--- a/lib/spandex_datadog/api_server/reporter.ex
+++ b/lib/spandex_datadog/api_server/reporter.ex
@@ -1,0 +1,91 @@
+defmodule SpandexDatadog.ApiServer.Reporter do
+  @moduledoc false
+  # This client module periodically grabs the information from the various buffers
+  # and sends it to datadog.
+  use GenServer
+
+  alias SpandexDatadog.ApiServer.Buffer
+  alias SpandexDatadog.ApiServer.Client
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc false
+  def flush do
+    GenServer.call(__MODULE__, :flush)
+  end
+
+  @doc false
+  def enable_verbose_logging do
+    GenServer.call(__MODULE__, {:verbose_logging, true})
+  end
+
+  @doc false
+  def disable_verbose_logging do
+    GenServer.call(__MODULE__, {:verbose_logging, false})
+  end
+
+  @doc false
+  def set_http_client(mod) do
+    GenServer.call(__MODULE__, {:set_http, mod})
+  end
+
+  def init(opts) do
+    host  = opts[:host]
+    port  = opts[:port]
+    state = %{
+      buffer: opts[:buffer],
+      collector_url: "#{host}:#{port}/v0.3/traces",
+      verbose?: opts[:verbose?],
+      http: opts[:http],
+      flush_period: opts[:flush_period] || 1_000,
+    }
+
+    schedule(state.flush_period)
+
+    {:ok, state}
+  end
+
+  # Only used for development and testing purposes
+  def handle_call(:flush, _, state) do
+    flush(state)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:verbose_logging, bool}, _, state) do
+    {:reply, :ok, %{state | verbose?: bool}}
+  end
+
+  def handle_call({:set_http, mod}, _, state) do
+    {:reply, :ok, %{state | http: mod}}
+  end
+
+  def handle_info(:flush, state) do
+    flush(state)
+    schedule(state.flush_period)
+
+    {:noreply, state}
+  end
+
+  defp flush(state) do
+    :telemetry.span([:spandex_datadog, :client, :flush], %{}, fn ->
+      Buffer.flush_latest(state.buffer, fn buffer ->
+        if buffer == [] do
+          :ok
+        else
+          Client.send(state.http, state.collector_url, buffer, verbose?: state.verbose?)
+        end
+      end)
+
+      {:ok, %{}}
+    end)
+  end
+
+  defp schedule(timeout) do
+    # next time = min(max(min_time * 2, 1_000), 1_000)
+    # If our minimum requests are taking way longer than 1 second than don't try
+    # schedule another
+    Process.send_after(self(), :flush, timeout)
+  end
+end


### PR DESCRIPTION
After #28, we determined that the call to add a new trace was taking several milliseconds in the general case and spiking up to 20ms under load. This PR is a re-write of the existing trace collection process in order to optimize callers and remove this as a bottleneck.

## New Technique

With this new method, all traces are buffered in a collection of write-optimized ETS tables. There is one ETS table per scheduler. When a caller writes a trace into the ets table, it first determines its current scheduler, and then writes the trace to the corresponding ets table. Using multiple ets tables in this way helps to reduce on write contention. Periodically (by default every second) a reporting process flushes the data from these ets tables and sends it to the datadog collector.

## Future Improvements

There are a few other improvements to make here down the line. The first is that this is now an unbounded buffer which is always a bad idea. We should provide a per-table, maximum number of traces that can be stored and reject new traces (or old traces) based on this maximum. This should remove the bottleneck from the callers and help ensure that we dont' have unbounded memory growth.

It is also probably still worth doing certain operations in a Task or separate, short-lived process to avoid memory bloat from binaries.

I'll work on both of these ideas, but I wanted to present this PR sooner in order to get y'alls input.