### PR TITLE
add container id to ApiServer.State and send in header

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -106,7 +106,7 @@ defmodule SpandexDatadog.ApiServer do
   @cgroup_uuid "[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
   @cgroup_ctnr "[0-9a-f]{64}"
   @cgroup_task "[0-9a-f]{32}-\\d+"
-  @cgroup_regex Regex.compile!("/(#{@cgroup_uuid}|#{@cgroup_ctnr}|#{@cgroup_task})(?:.scope)?$", "m")
+  @cgroup_regex Regex.compile!(".*(#{@cgroup_uuid}|#{@cgroup_ctnr}|#{@cgroup_task})(?:\\.scope)?$", "m")
 
   defp get_container_id() do
     with {:ok, file_binary} <- File.read("/proc/self/cgroup"),


### PR DESCRIPTION
Adds a `Datadog-Container-ID` header when a container is being used.
Modeled on the [DD Node.js client code](https://github.com/DataDog/dd-trace-js)

Happy to add a couple tests if required but would need some guidance — the file read might require a mock setup.