### PR TITLE
improvement: configurable default span priority

### DIFF
--- a/lib/spandex_datadog/adapter.ex
+++ b/lib/spandex_datadog/adapter.ex
@@ -55,7 +55,9 @@ defmodule SpandexDatadog.Adapter do
   def distributed_context(headers, _opts) do
     trace_id = get_header(headers, "x-datadog-trace-id")
     parent_id = get_header(headers, "x-datadog-parent-id")
-    priority = get_header(headers, "x-datadog-sampling-priority") || 1
+
+    priority =
+      get_header(headers, "x-datadog-sampling-priority") || Application.get_env(:spandex_datadog, :default_priority, 1)
 
     if is_nil(trace_id) || is_nil(parent_id) do
       {:error, :no_distributed_trace}

--- a/lib/spandex_datadog/adapter.ex
+++ b/lib/spandex_datadog/adapter.ex
@@ -56,8 +56,7 @@ defmodule SpandexDatadog.Adapter do
     trace_id = get_header(headers, "x-datadog-trace-id")
     parent_id = get_header(headers, "x-datadog-parent-id")
 
-    priority =
-      get_header(headers, "x-datadog-sampling-priority") || Application.get_env(:spandex_datadog, :default_priority, 1)
+    priority = get_header(headers, "x-datadog-sampling-priority") || Application.get_env(:spandex, :default_priority, 1)
 
     if is_nil(trace_id) || is_nil(parent_id) do
       {:error, :no_distributed_trace}

--- a/lib/spandex_datadog/adapter.ex
+++ b/lib/spandex_datadog/adapter.ex
@@ -55,7 +55,6 @@ defmodule SpandexDatadog.Adapter do
   def distributed_context(headers, _opts) do
     trace_id = get_header(headers, "x-datadog-trace-id")
     parent_id = get_header(headers, "x-datadog-parent-id")
-
     priority = get_header(headers, "x-datadog-sampling-priority") || Application.get_env(:spandex, :default_priority, 1)
 
     if is_nil(trace_id) || is_nil(parent_id) do

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -159,7 +159,7 @@ defmodule SpandexDatadog.ApiServer do
   @deprecated "Please use format/3 instead"
   @doc false
   @spec format(Span.t()) :: map()
-  def format(%Span{} = span), do: format(span, 1, [])
+  def format(%Span{} = span), do: format(span, Application.get_env(:spandex, :default_priority, 1), [])
 
   @spec format(Span.t(), integer(), Keyword.t()) :: map()
   def format(%Span{} = span, priority, _baggage) do

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -174,14 +174,23 @@ defmodule SpandexDatadog.ApiServer do
       resource: span.resource || span.name,
       service: span.service,
       type: span.type,
-      meta: meta(span),
-      metrics:
-        metrics(span, %{
-          _sampling_priority_v1: priority,
-          "_dd.rule_psr": 1.0,
-          "_dd.limit_psr": 1.0
-        })
+      meta: meta(span)
     }
+    |> then(fn data ->
+      if priority do
+        Map.put(
+          data,
+          :metrics,
+          metrics(span, %{
+            _sampling_priority_v1: priority,
+            "_dd.rule_psr": 1.0,
+            "_dd.limit_psr": 1.0
+          })
+        )
+      else
+        data
+      end
+    end)
   end
 
   # Private Helpers


### PR DESCRIPTION
Right now we assume that we should explicitly mark any span as 100% sampled, but that is problematic because agent ingestion controls can't be used. This makes it configurable.