### PR TITLE
feat: add datadog meta headers

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -35,7 +35,11 @@ defmodule SpandexDatadog.ApiServer do
   # Same as HTTPoison.headers
   @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary} | any
 
-  @headers [{"Content-Type", "application/msgpack"}]
+  @headers [
+    {"Content-Type", "application/msgpack"},
+    {"Datadog-Meta-Lang", "elixir"},
+    {"Datadog-Meta-Lang-Version", System.version()}
+  ]
 
   @default_opts [
     host: "localhost",

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -38,7 +38,8 @@ defmodule SpandexDatadog.ApiServer do
   @headers [
     {"Content-Type", "application/msgpack"},
     {"Datadog-Meta-Lang", "elixir"},
-    {"Datadog-Meta-Lang-Version", System.version()}
+    {"Datadog-Meta-Lang-Version", System.version()},
+    {"Datadog-Meta-Tracer-Version", Application.spec(:spandex_datadog)[:vsn]}
   ]
 
   @default_opts [

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -232,6 +232,9 @@ defmodule SpandexDatadog.ApiServerTest do
 
       headers = [
         {"Content-Type", "application/msgpack"},
+        {"Datadog-Meta-Lang", "elixir"},
+        {"Datadog-Meta-Lang-Version", System.version()},
+        {"Datadog-Meta-Tracer-Version", nil},
         {"X-Datadog-Trace-Count", 1}
       ]
 


### PR DESCRIPTION
Adds `Datadog-Meta-*` headers to the request that pushes the traces to the agent.

It seems that some specific tags are redacted by Datadog's backend and don't show in their UI if these headers are not set.
Two examples of these tags are: `http.client_ip` and `network.client.ip`.

We encountered this problem and contacted Datadog's support. This was there message with the solution:

> Currently, all traces submitted with a client IP or similar value, have that client IP redacted on our back end automatically. To avoid this, you will need to set the `Datadog-Meta-Lang` and `Datadog-Meta-Tracer-Version` headers in the payload when making the requests to the Agent API. This should then let you keep the values anyway, and avoid them being redacted.