### PR TITLE
fix: convert tags boolean values different from other atoms

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -432,6 +432,7 @@ defmodule SpandexDatadog.ApiServer do
 
   defp deep_remove_nils(term), do: term
 
+  defp term_to_string(term) when is_boolean(term), do: inspect(term)
   defp term_to_string(term) when is_binary(term), do: term
   defp term_to_string(term) when is_atom(term), do: term
   defp term_to_string(term), do: inspect(term)

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -51,7 +51,7 @@ defmodule SpandexDatadog.ApiServerTest do
         name: "foo",
         trace_id: trace_id,
         completion_time: 1_527_752_052_216_578_000,
-        tags: [foo: "123", bar: 321, buz: :blitz, baz: {1, 2}, zyx: [xyz: {1, 2}]]
+        tags: [is_foo: true, foo: "123", bar: 321, buz: :blitz, baz: {1, 2}, zyx: [xyz: {1, 2}]]
       )
 
     {:ok, span_2} =
@@ -176,6 +176,7 @@ defmodule SpandexDatadog.ApiServerTest do
             "buz" => "blitz",
             "env" => "local",
             "foo" => "123",
+            "is_foo" => "true",
             "version" => "v1",
             "zyx" => "[xyz: {1, 2}]"
           },
@@ -267,6 +268,7 @@ defmodule SpandexDatadog.ApiServerTest do
             "buz" => "blitz",
             "env" => "local",
             "foo" => "123",
+            "is_foo" => "true",
             "version" => "v1",
             "zyx" => "[xyz: {1, 2}]"
           },


### PR DESCRIPTION
The Datadog agent trace API only supports strings for metadata keys and values.

We encountered an error when we tried to send tags with booleans as values.

This should convert booleans like we do for other terms.